### PR TITLE
Changed from appliedLatency to relativeLatency

### DIFF
--- a/pt-plugin-tungsten_replicator.pl
+++ b/pt-plugin-tungsten_replicator.pl
@@ -56,7 +56,7 @@ sub get_slave_lag {
          }
 
 
-         $lag = sprintf("%.0f", $status->{appliedLatency});
+         $lag = sprintf("%.0f", $status->{relativeLatency});
 
          # we return oktorun and the lag
          return $lag;


### PR DESCRIPTION
In testing, appliedLatency can remain low if no additional statements come in, as appliedLatency only tracks the variance between when a statement was applied on the Primary, and when it was applied on the secondary nodes.
relativeLatency will gauge the state of the secondary node relative to the primary, which should more accurately account for replication lag.